### PR TITLE
Make the build system a little smarter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(SOURCE_FILES
         src/include/UI/UIElementList.hpp
         src/include/UI/UIHeapUsageElement.hpp
         src/include/GX.hpp
-        src/include/ReadFile.hpp
+        src/include/readFile.hpp
         src/include/prime/CMFGame.hpp
         src/include/prime/CIOWinManager.hpp
         src/include/prime/CGameAllocator.hpp

--- a/compile.sh
+++ b/compile.sh
@@ -2,6 +2,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 python3 ./PrimeAPI/script/BuildModule.py . default.dol -v
-cp -v default_mod.dol ../mp1/files/default.dol
-cp -v default_mod.dol ../mp1/sys/main.dol
-cp -v build/Mod.rel ../mp1/files/Mod.rel
+ret=$?
+if [ $ret -eq 0 ]; then
+  cp -v default_mod.dol ../mp1/files/default.dol
+  cp -v default_mod.dol ../mp1/sys/main.dol
+  cp -v build/Mod.rel ../mp1/files/Mod.rel
+else
+  echo Failed to compile module
+fi


### PR DESCRIPTION
Make the build system a little smarter by determining GCC version at launch, and give `compile.sh` an actual result