### PR TITLE
Support LLVM 11

### DIFF
--- a/PrimeAPI2/PrimeAPI.cmake
+++ b/PrimeAPI2/PrimeAPI.cmake
@@ -45,7 +45,7 @@ set(CMAKE_PRIME_LINK_FLAGS_LIST
 #        "-z combreloc"
 #        -call_shared
 #        --strip-discarded
-        --gc-sections
+#        --gc-sections
         "-e __rel_prolog"
         "--unresolved-symbols=report-all"
         --error-unresolved-symbols


### PR DESCRIPTION
The combination of --gc-sections and -r is currently unsupported by the version of lld that is released (11). Removing --gc-sections fixes the issue, and appears to not cause any regressions.

https://bugs.llvm.org/show_bug.cgi?id=46700