### PR TITLE
Add death feature in player menu

### DIFF
--- a/src/UI/PlayerMenu.cpp
+++ b/src/UI/PlayerMenu.cpp
@@ -113,9 +113,21 @@ namespace GUI {
         player->setFluidCounter((u32) fluidCounter);
       }
       ImGui::DragFloat("Water depth", player->getDepthUnderWater(), 1.f, -FLT_MAX, FLT_MAX, "%.3f", flags);
+      if (ImGui::Button("Death")) {
+        kill();
+      }
 
       ImGui::TreePop();
     }
+  }
+
+  void kill() {
+    CStateManager *stateManager = CStateManager_INSTANCE;
+    CPlayerState *playerState = stateManager->GetPlayerState();
+
+    // game checks for flags & 0x80000000 to tell if player is alive
+    // if flag is set then the player is alive
+    player->flags &= ~(1 << 31);
   }
 
   void loadPos() {


### PR DESCRIPTION
Adds a death button in player menu
It edits the flags in CPlayerState to tell that the player is not alive which triggers the death animation and brings you to the game over screen.